### PR TITLE
Block text directive

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,33 @@
+## [v0.2.0]
+> Jul 17, 2016
+
+The new block text directive allows you to write text without Expug parsing.
+
+```jade
+script.
+  if (usingExpug) {
+    alert('Awesome!')
+  }
+```
+
+[v0.2.0]: https://github.com/rstacruz/expug/compare/v0.1.1...v0.2.0
+
+## [v0.1.1]
+> Jul 17, 2016
+
+Expug now supports `if do ... end` and other blocks.
+
+```jade
+= if @error do
+  .alert Uh oh! Check your form and try again.
+```
+
+[v0.1.1]: https://github.com/rstacruz/expug/compare/v0.0.1...v0.1.1
+
+## [v0.0.1]
+> Jul 17, 2016
+
+Initial release.
+
+[v0.0.1]: https://github.com/rstacruz/expug/tree/v0.0.1
+

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Also see [phoenix_expug](https://github.com/rstacruz/phoenix_expug) for Phoenix 
 
 Expug lets you write HTML as indented shorthand, inspired by Haml, Slim, Pug/Jade, and so on.
 
-<iframe src='https://try-expug.herokuapp.com/try' height='400' width='100%' style='border: 0'></iframe>
+<iframe src='https://try-expug.herokuapp.com/try?code=doctype%20html%0Ahtml%0A%20%20head%0A%20%20%20%20meta(charset%3D%22utf-8%22)%0A%20%20%20%20title%20Hello%0A%20%20body%0A%20%20%20%20a.button(href%3D%40link)%0A%20%20%20%20%20%20%7C%20This%20is%20a%20link' height='400' width='100%' style='border: 0'></iframe>
 
 ```jade
 doctype html

--- a/docs/syntax/elements.md
+++ b/docs/syntax/elements.md
@@ -1,0 +1,73 @@
+# Syntax: Elements
+
+Elements are just lines.
+
+```jade
+div
+```
+
+## Class names and ID's
+
+You may add `.classes` and `#id`s after an element name.
+
+```jade
+p.alert
+div#box
+```
+
+If you do, the element name is optional.
+
+```jade
+#box
+.alert
+```
+
+You may chain them as much as you need to.
+
+```jade
+.alert.alert-danger#error
+```
+
+## Attributes
+
+Enclose attributes in `(...)` after an element name.
+
+```jade
+a(href="google.com") Google
+a(class="button" href="google.com") Google
+.box(style="display: none")
+```
+
+The attribute values are Elixir expressions.
+
+```jade
+script(src=static_path(@conn, "/js/app.js"))
+```
+
+## Text
+
+Text after the classes/attributes are shown as plain text. See [text](text.html).
+
+```jade
+a(href="google.com") Google
+```
+
+You may also use `|` for plain text with other elements.
+
+```jade
+div
+  | Welcome, new user!
+  a(href="/signup") Register
+```
+
+## Nesting
+
+Nest elements by indentation.
+
+```jade
+ul
+  li
+    a(href="/") Home
+  li
+    a(href="/about") About
+```

--- a/docs/syntax/text.md
+++ b/docs/syntax/text.md
@@ -1,0 +1,33 @@
+# Syntax: Text
+
+## Piped text
+
+The simplest way of adding plain text to templates is to prefix the line with a `|` character.
+
+```jade
+| Plain text can include <strong>html</strong>
+p
+  | It must always be on its own line
+```
+
+## Inline in a Tag
+
+Since it's a common use case, you can put text in a tag just by adding it inline after a space.
+
+```jade
+p Plain text can include <strong>html</strong>
+```
+
+## Block text
+
+Often you might want large blocks of text within a tag. A good example is with inline scripts or styles. To do this, just add a `.` after the tag (with no preceding space):
+
+```jade
+script.
+  if (usingExpug)
+    console.log('you are awesome')
+  else
+    console.log('use expug')
+```
+
+<!-- Based on http://jade-lang.com/reference/plain-text/ -->

--- a/lib/expug/builder.ex
+++ b/lib/expug/builder.ex
@@ -111,7 +111,7 @@ defmodule Expug.Builder do
     |> put(node, "<%= raw(#{value}) %>")
   end
 
-  def make(doc, %{type: :free_text, value: value} = node) do
+  def make(doc, %{type: :block_text, value: value} = node) do
     doc
     |> put(node, value)
   end

--- a/lib/expug/builder.ex
+++ b/lib/expug/builder.ex
@@ -111,6 +111,11 @@ defmodule Expug.Builder do
     |> put(node, "<%= raw(#{value}) %>")
   end
 
+  def make(doc, %{type: :free_text, value: value} = node) do
+    doc
+    |> put(node, value)
+  end
+
   def make(doc, nil) do
     doc
   end

--- a/lib/expug/compiler.ex
+++ b/lib/expug/compiler.ex
@@ -112,7 +112,7 @@ defmodule Expug.Compiler do
       :element_class
       :element_id
       [:attribute_open [...] :attribute_close]
-      [:solo_buffered_text | :solo_raw_text]
+      [:buffered_text | :raw_text | :free_text]
   """
   def statement({node, [{_, :line_comment, _} | [{_, :subindent, _} | _] = tokens]}, _depths) do
     # Pretend to be an element and capture stuff into it; discard it afterwards.
@@ -202,6 +202,13 @@ defmodule Expug.Compiler do
         node = add_child(node, child)
         element({node, rest}, parent, depths)
 
+      [{_, :free_text, _} | rest] ->
+        t = hd(rest)
+        {rest, lines} = subindent_capture(rest)
+        child = %{type: :free_text, value: lines, token: t}
+        node = add_child(node, child)
+        element({node, rest}, parent, depths)
+
       [{_, :attribute_open, _} | rest] ->
         {attr_list, rest} = attribute({node[:attributes] || %{}, rest})
         node = Map.put(node, :attributes, attr_list)
@@ -256,5 +263,15 @@ defmodule Expug.Compiler do
 
   def subindent({node, rest}) do
      {node, rest}
+  end
+
+  def subindent_capture(tokens, lines \\ [])
+  def subindent_capture([{_, :subindent, line} | rest], lines) do
+    lines = lines ++ line
+    subindent_capture(rest, lines)
+  end
+
+  def subindent_capture(rest, lines) do
+    {rest, lines}
   end
 end

--- a/lib/expug/compiler.ex
+++ b/lib/expug/compiler.ex
@@ -112,7 +112,7 @@ defmodule Expug.Compiler do
       :element_class
       :element_id
       [:attribute_open [...] :attribute_close]
-      [:buffered_text | :raw_text | :free_text]
+      [:buffered_text | :raw_text | :block_text]
   """
   def statement({node, [{_, :line_comment, _} | [{_, :subindent, _} | _] = tokens]}, _depths) do
     # Pretend to be an element and capture stuff into it; discard it afterwards.
@@ -202,10 +202,10 @@ defmodule Expug.Compiler do
         node = add_child(node, child)
         element({node, rest}, parent, depths)
 
-      [{_, :free_text, _} | rest] ->
+      [{_, :block_text, _} | rest] ->
         t = hd(rest)
         {rest, lines} = subindent_capture(rest)
-        child = %{type: :free_text, value: lines, token: t}
+        child = %{type: :block_text, value: lines, token: t}
         node = add_child(node, child)
         element({node, rest}, parent, depths)
 

--- a/lib/expug/tokenizer.ex
+++ b/lib/expug/tokenizer.ex
@@ -244,6 +244,7 @@ defmodule Expug.Tokenizer do
   def attribute_bracket(state) do
     state
     |> eat(~r/^\[/, :attribute_open)
+    |> optional_whitespace()
     |> optional(&attribute_list/1)
     |> eat(~r/^\]/, :attribute_close)
   end
@@ -251,6 +252,7 @@ defmodule Expug.Tokenizer do
   def attribute_paren(state) do
     state
     |> eat(~r/^\(/, :attribute_open)
+    |> optional_whitespace()
     |> optional(&attribute_list/1)
     |> eat(~r/^\)/, :attribute_close)
   end
@@ -258,6 +260,7 @@ defmodule Expug.Tokenizer do
   def attribute_brace(state) do
     state
     |> eat(~r/^\{/, :attribute_open)
+    |> optional_whitespace()
     |> optional(&attribute_list/1)
     |> eat(~r/^\}/, :attribute_close)
   end

--- a/lib/expug/tokenizer.ex
+++ b/lib/expug/tokenizer.ex
@@ -169,7 +169,7 @@ defmodule Expug.Tokenizer do
       |> one_of([
         &sole_buffered_text/1,
         &sole_raw_text/1,
-        &free_text/1
+        &block_text/1
       ])
     end)
   end
@@ -366,9 +366,9 @@ defmodule Expug.Tokenizer do
     |> optional(&subindent_block/1)
   end
 
-  def free_text(state) do
+  def block_text(state) do
     state
-    |> eat(~r/\./, :free_text)
+    |> eat(~r/\./, :block_text)
     |> subindent_block()
   end
 

--- a/lib/expug/tokenizer.ex
+++ b/lib/expug/tokenizer.ex
@@ -168,7 +168,8 @@ defmodule Expug.Tokenizer do
     |> optional(fn s -> s
       |> one_of([
         &sole_buffered_text/1,
-        &sole_raw_text/1
+        &sole_raw_text/1,
+        &free_text/1
       ])
     end)
   end
@@ -363,6 +364,12 @@ defmodule Expug.Tokenizer do
     |> optional_whitespace()
     |> eat(~r/^[^\n]*/, :line_comment)
     |> optional(&subindent_block/1)
+  end
+
+  def free_text(state) do
+    state
+    |> eat(~r/\./, :free_text)
+    |> subindent_block()
   end
 
   def subindent_block(state) do

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -468,7 +468,7 @@ defmodule ExpugCompilerTest do
         name: "script",
         token: {{1, 1}, :element_name, "script"},
         children: [%{
-          type: :free_text,
+          type: :block_text,
           value: "alert('hello')",
           token: {{2, 3}, :subindent, "alert('hello')"}
         }],

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -457,4 +457,23 @@ defmodule ExpugCompilerTest do
       }]
     } == ast
   end
+
+  test "script." do
+    tokens = tokenize("script.\n  alert('hello')")
+    ast = compile(tokens)
+    assert %{
+      type: :document,
+      children: [%{
+        type: :element,
+        name: "script",
+        token: {{1, 1}, :element_name, "script"},
+        children: [%{
+          type: :free_text,
+          value: "alert('hello')",
+          token: {{2, 3}, :subindent, "alert('hello')"}
+        }],
+      }]
+    } == ast
+  end
+
 end

--- a/test/expug_test.exs
+++ b/test/expug_test.exs
@@ -36,12 +36,12 @@ defmodule ExpugTest do
     assert %{
       type: :parse_error,
       position: {2, 4},
-      expected: [:eq, :whitespace, :free_text, :attribute_open]
+      expected: [:eq, :whitespace, :block_text, :attribute_open]
     } = output
   end
 
   test "bang, parse error" do
-    msg = "parse error, expected one of: eq, whitespace, free_text, attribute_open on line 2 col 4"
+    msg = "parse error, expected one of: eq, whitespace, block_text, attribute_open on line 2 col 4"
     assert_raise Expug.Error, msg, fn ->
       Expug.to_eex!("hello\nhuh?")
     end

--- a/test/expug_test.exs
+++ b/test/expug_test.exs
@@ -36,12 +36,12 @@ defmodule ExpugTest do
     assert %{
       type: :parse_error,
       position: {2, 4},
-      expected: [:eq, :whitespace, :attribute_open]
+      expected: [:eq, :whitespace, :free_text, :attribute_open]
     } = output
   end
 
   test "bang, parse error" do
-    msg = "parse error, expected one of: eq, whitespace, attribute_open on line 2 col 4"
+    msg = "parse error, expected one of: eq, whitespace, free_text, attribute_open on line 2 col 4"
     assert_raise Expug.Error, msg, fn ->
       Expug.to_eex!("hello\nhuh?")
     end

--- a/test/stringifier_test.exs
+++ b/test/stringifier_test.exs
@@ -172,7 +172,14 @@ defmodule StringifierTest do
   test "-// comment nesting"
 
   @tag :pending
-  test "script."
+  test "script." do
+    eex = build("""
+    script.
+      alert("hi")
+    """)
+
+    assert eex == ""
+  end
 
   @tag :pending
   test "ul: li: button Hello"

--- a/test/stringifier_test.exs
+++ b/test/stringifier_test.exs
@@ -171,14 +171,16 @@ defmodule StringifierTest do
   @tag :pending
   test "-// comment nesting"
 
-  @tag :pending
   test "script." do
     eex = build("""
     script.
       alert("hi")
     """)
 
-    assert eex == ""
+    assert eex == ~S"""
+    <script>
+    alert("hi")<%= "\n" %></script>
+    """
   end
 
   @tag :pending

--- a/test/stringifier_test.exs
+++ b/test/stringifier_test.exs
@@ -152,7 +152,7 @@ defmodule StringifierTest do
     assert eex == ""
   end
 
-  test "empty attributes" do
+  test "empty space attributes" do
     eex = build("div( )")
 
     assert eex == "<div></div>\n"

--- a/test/stringifier_test.exs
+++ b/test/stringifier_test.exs
@@ -152,12 +152,10 @@ defmodule StringifierTest do
     assert eex == ""
   end
 
-  @tag :pending
-  @tag :next
   test "empty attributes" do
     eex = build("div( )")
 
-    assert eex == "<div></div>"
+    assert eex == "<div></div>\n"
   end
 
   @tag :pending

--- a/test/tokenizer_test.exs
+++ b/test/tokenizer_test.exs
@@ -227,7 +227,7 @@ defmodule ExpugTokenizerTest do
       assert %{
         type: :parse_error,
         position: {2, 4},
-        expected: [:eq, :whitespace, :free_text, :attribute_open]
+        expected: [:eq, :whitespace, :block_text, :attribute_open]
       } = output
     end
   end
@@ -553,7 +553,7 @@ defmodule ExpugTokenizerTest do
     assert reverse(output) == [
       {{1, 1}, :indent, 0},
       {{1, 1}, :element_name, "script"},
-      {{1, 7}, :free_text, "."},
+      {{1, 7}, :block_text, "."},
       {{2, 3}, :subindent, "hello"}
     ]
   end
@@ -564,7 +564,7 @@ defmodule ExpugTokenizerTest do
       {{1, 1}, :indent, 0},
       {{1, 1}, :element_name, "script"},
       {{1, 8}, :element_class, "box"},
-      {{1, 11}, :free_text, "."},
+      {{1, 11}, :block_text, "."},
       {{2, 3}, :subindent, "hello"}
     ]
   end
@@ -579,7 +579,7 @@ defmodule ExpugTokenizerTest do
       {{1, 12}, :attribute_key, "id"},
       {{1, 15}, :attribute_value, "\"foo\""},
       {{1, 20}, :attribute_close, ")"},
-      {{1, 21}, :free_text, "."},
+      {{1, 21}, :block_text, "."},
       {{2, 3}, :subindent, "hello"}
     ]
   end
@@ -589,7 +589,7 @@ defmodule ExpugTokenizerTest do
     assert reverse(output) == [
       {{1, 1}, :indent, 0},
       {{1, 1}, :element_name, "script"},
-      {{1, 7}, :free_text, "."},
+      {{1, 7}, :block_text, "."},
       {{2, 3}, :subindent, "hello"},
       {{3, 3}, :subindent, "  world"}
     ]
@@ -600,7 +600,7 @@ defmodule ExpugTokenizerTest do
     assert reverse(output) == [
       {{1, 1}, :indent, 0},
       {{1, 1}, :element_name, "script"},
-      {{1, 7}, :free_text, "."},
+      {{1, 7}, :block_text, "."},
       {{2, 3}, :subindent, "hello"},
       {{3, 3}, :subindent, "  world"},
       {{4, 1}, :indent, 0},


### PR DESCRIPTION
This adds support for the dot (`.`), which in Expug is called `:block_text`:

``` jade
script.
  alert("hello!")
  // things here will not be evaluated as expug elements/comments/etc.
```

``` html
<script>
alert("hello!")
// things here will not be evaluated as expug elements/comments/etc.
</script>
```
