### PR TITLE
Multiline expressions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## [v0.2.0]
 > Unreleased
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,5 @@
 ## [v0.2.0]
-> Jul 17, 2016
+> Unreleased
 
 The new block text directive allows you to write text without Expug parsing.
 
@@ -8,6 +8,16 @@ script.
   if (usingExpug) {
     alert('Awesome!')
   }
+```
+
+Added support for multiline code. Lines ending in `{`, `(`, `[` or `,` will assume to be wrapped.
+
+```jade
+= render App.FooView, "nav.html",
+  conn: @conn,
+  action: {
+    "Create new",
+    item_path(@conn, :new) }
 ```
 
 [v0.2.0]: https://github.com/rstacruz/expug/compare/v0.1.1...v0.2.0

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ body
 
 Also see:
 
-- [Comparison with Pug](docs/compatibility_with_pug.md)
+- [Comparison with Pug](docs/misc/compatibility_with_pug.md)
 - [Jade language reference](http://jade-lang.com/reference/) (jade-lang.com)
 
 ## Prior art

--- a/docs/misc/compatibility_with_pug.md
+++ b/docs/misc/compatibility_with_pug.md
@@ -1,4 +1,4 @@
-# Compatibility with Pug
+# Misc: Compatibility with Pug
 
 Expug retains most of Pug/Jade's features, adds some Elixir'isms, and drops the features that don't make sense.
 

--- a/docs/misc/line_number_preservation.md
+++ b/docs/misc/line_number_preservation.md
@@ -1,4 +1,4 @@
-# New line preservation
+# Misc: Line number preservation
 
 Eex has no provisions for source maps, so we'll have to emulate this by outputing EEx that matches line numbers *exactly* with the source `.pug` files.
 

--- a/docs/syntax/code.md
+++ b/docs/syntax/code.md
@@ -1,0 +1,45 @@
+# Syntax: Code
+
+## Unbuffered code
+Unbuffered code starts with `-` does not add any output directly.
+
+```jade
+- name = assigns.name
+div(id="name-#{name}")
+```
+
+## Bufferred code
+
+Buffered code starts with `=` and outputs the result of evaluating the Elixir expression in the template. For security, it is first HTML escaped.
+
+```jade
+p= "Hello, #{name}"
+```
+
+## Conditionals and Loops
+
+For `if`, `cond`, `try`, `for`, an `end` statement is automatically inferred.
+
+```jade
+= if assigns.name do
+  = "Hello, #{@name}"
+```
+
+They also need to begin with `=`, not `-`. Except for `else`, `rescue` and so on.
+
+```jade
+= if assigns.current_user do
+  | Welcome.
+- else
+  | You are not signed in.
+```
+
+## Multiline
+
+If a line ends in one of these characters: `,` `(` `{` `[`, the next line is considered to be part of the Elixir expression.
+
+```jade
+= render App.PageView,
+  "index.html",
+  conn: @conn
+```

--- a/lib/expug/tokenizer.ex
+++ b/lib/expug/tokenizer.ex
@@ -408,7 +408,7 @@ defmodule Expug.Tokenizer do
     state
     |> discard(~r/^=/, :eq)
     |> optional_whitespace()
-    |> eat(~r/^[^\n$]+/, :buffered_text)
+    |> eat(~r/^(?:[,\[\(\{]\s*\n|[^\n$])+/, :buffered_text)
   end
 
   def raw_text(state) do
@@ -422,7 +422,7 @@ defmodule Expug.Tokenizer do
     state
     |> discard(~r/^\-/, :dash)
     |> optional_whitespace()
-    |> eat(~r/^[^\n$]+/, :statement)
+    |> eat(~r/^(?:[,\[\(\{]\s*\n|[^\n$])+/, :statement)
   end
 
   @doc ~S"""

--- a/mix.exs
+++ b/mix.exs
@@ -48,10 +48,9 @@ defmodule Expug.Mixfile do
     [
       source_ref: "v#{@version}",
       main: "readme",
-      extras: [
-        Path.wildcard("*.md") |
+      extras:
+        Path.wildcard("*.md") ++
         Path.wildcard("docs/**/*.md")
-      ]
     ]
   end
 end

--- a/test/stringifier_test.exs
+++ b/test/stringifier_test.exs
@@ -185,4 +185,32 @@ defmodule StringifierTest do
 
   @tag :pending
   test "ul: li: button Hello"
+
+  test "multiline" do
+    eex = build("""
+    - render(
+      @conn)
+    div
+    """)
+
+    assert eex == ~S"""
+    <% render(
+      @conn) %>
+    <div></div>
+    """
+  end
+
+  test "multiline =" do
+    eex = build("""
+    = render(
+      @conn)
+    div
+    """)
+
+    assert eex == ~S"""
+    <%= render(
+      @conn) %>
+    <div></div>
+    """
+  end
 end

--- a/test/tokenizer_test.exs
+++ b/test/tokenizer_test.exs
@@ -256,6 +256,24 @@ defmodule ExpugTokenizerTest do
     ]
   end
 
+  test "- statement multiline" do
+    output = tokenize("- text,\n  foo")
+    assert reverse(output) == [
+      {{1, 1}, :indent, 0},
+      {{1, 3}, :statement, "text,\n  foo"}
+    ]
+  end
+
+  test "- statement multiline (2)" do
+    output = tokenize("- text(\n  foo)\ndiv")
+    assert reverse(output) == [
+      {{1, 1}, :indent, 0},
+      {{1, 3}, :statement, "text(\n  foo)"},
+      {{3, 1}, :indent, 0},
+      {{3, 1}, :element_name, "div"}
+    ]
+  end
+
   test "doctype" do
     output = tokenize("doctype html5")
     assert reverse(output) == [


### PR DESCRIPTION
Added support for multiline code. Lines ending in `{`, `(`, `[` or `,` will assume to be wrapped.

``` jade
= render App.FooView, "nav.html",
  conn: @conn,
  action: {
    "Create new",
    item_path(@conn, :new) }
```
