### PR TITLE
Fix attribute value escaping

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [v0.3.0]
+> Jul 21, 2016
+
+[#3] - Attribute values are now escaped properly. This means you can now properly do:
+
+```jade
+- json = "{\"hello\":\"world\"}"
+div(data-value=json)
+```
+
+```html
+<div data-value="{&quot;hello&quot;:&quot;world&quot;}">
+```
+
+`nil` values are also now properly handled, along with boolean values.
+
+```jade
+textarea(spellcheck=nil)
+textarea(spellcheck=true)
+textarea(spellcheck=false)
+```
+
+```html
+<textarea></textarea>
+<textarea spellcheck></textarea>
+<textarea></textarea>
+```
+
+[#3]: https://github.com/rstacruz/expug/issues/3
+[v0.3.0]: https://github.com/rstacruz/expug/compare/v0.2.0...v0.3.0
+
 ## [v0.2.0]
 > Jul 17, 2016
 

--- a/lib/expug/runtime.ex
+++ b/lib/expug/runtime.ex
@@ -11,7 +11,15 @@ defmodule Expug.Runtime do
   Quotes a given `str` for use as an HTML attribute.
   """
   def attr_value(str) do
-    inspect("#{str}") # TODO: encodeURIComponent
+    "\"#{attr_value_escape(str)}\""
+  end
+
+  def attr_value_escape(str) do
+    str
+    |> String.replace("&", "&amp;")
+    |> String.replace("\"", "&quot;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
   end
 
   def attr(key, true) do
@@ -19,6 +27,10 @@ defmodule Expug.Runtime do
   end
 
   def attr(_key, false) do
+    ""
+  end
+
+  def attr(_key, nil) do
     ""
   end
 

--- a/test/runtime_test.exs
+++ b/test/runtime_test.exs
@@ -1,0 +1,26 @@
+defmodule Expug.RuntimeTest do
+  use ExUnit.Case
+  doctest Expug.Runtime
+
+  import Expug.Runtime
+
+  test "strings" do
+    assert attr("value", "hello") == ~S( value="hello")
+  end
+
+  test "escaping" do
+    assert attr("value", ~S(<h1 a="b">)) == ~S( value="&lt;h1 a=&quot;b&quot;&gt;")
+  end
+
+  test "boolean false" do
+    assert attr("disabled", false) == ""
+  end
+
+  test "boolean true" do
+    assert attr("disabled", true) == " disabled"
+  end
+
+  test "nil" do
+    assert attr("disabled", nil) == ""
+  end
+end


### PR DESCRIPTION
Attribute values are now escaped properly. This means you can now properly do:

``` jade
- json = "{\"hello\":\"world\"}"
div(data-value=json)
```

``` html
<div data-value="{&quot;hello&quot;:&quot;world&quot;}">
```

`nil` values are also now properly handled, along with boolean values.

``` jade
textarea(spellcheck=nil)
textarea(spellcheck=true)
textarea(spellcheck=false)
```

``` html
<textarea></textarea>
<textarea spellcheck></textarea>
<textarea></textarea>
```
