### PR TITLE
Fix `sole_raw_text` to allow `$`

### DIFF
--- a/lib/expug/tokenizer.ex
+++ b/lib/expug/tokenizer.ex
@@ -380,7 +380,7 @@ defmodule Expug.Tokenizer do
   def sole_raw_text(state) do
     state
     |> whitespace()
-    |> eat(~r/^[^\n$]+/, :raw_text)
+    |> eat(~r/^[^\n]+$/, :raw_text)
   end
 
   @doc "Matches `title` in `title= hello`"

--- a/test/tokenizer_test.exs
+++ b/test/tokenizer_test.exs
@@ -359,6 +359,16 @@ defmodule ExpugTokenizerTest do
     ]
   end
 
+  test ~S[div $100] do
+    output = tokenize(~S[div $100])
+    assert reverse(output) == [
+      {{1, 1}, :indent, 0},
+      {{1, 1}, :element_name, "div"},
+      {{1, 5}, :raw_text, "$100"}
+    ]
+  end
+
+
   test "with indent" do
     output = tokenize("head\n  title")
     assert reverse(output) == [


### PR DESCRIPTION
# Changes
Changes the regex expression:
from: `~r/^[^\n$]+/`
to: `~r/^[^\n]+$/`

The former matches the `$` literally, while the new change will `asserts position at the end of the string, or before the line terminator right at the end of the string (if any)`

# Issues
Fixes #7 